### PR TITLE
Display error text from api instead of general error message when an api action fails around dialogs

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -34,6 +34,19 @@ $(document).ready(function() {
   var $profile = $('.profile-container');
   var $userInput = $('.user-input');
 
+  var getErrorMessageFromResponse = function(response){
+    try{
+      if(!response.responseText) return ''
+      var errorObject = JSON.parse(response.responseText)
+      if(!errorObject.error) return ''
+      return errorObject.error
+    }catch(e){
+      if(e instanceof SyntaxError)
+        return ''
+      throw e
+    }
+  }
+
   /**
    * Loads the dialog-container
    */
@@ -50,9 +63,10 @@ $(document).ready(function() {
       dialogs.forEach(function(dialog, index) {
         createDialogTemplate(dialog, index).appendTo($dialogs);
        });
-    }).fail(function() {
+    }).fail(function(response) {
+      var errorText = getErrorMessageFromResponse(response)
       $dialogsError.show();
-      $dialogsError.find('.errorMsg').html('Error getting the dialogs.');
+      $dialogsError.find('.errorMsg').html('Error getting the dialogs' + (errorText?': '+errorText:'.'));
     })
     .always(function(){
       $dialogsLoading.hide();
@@ -158,9 +172,11 @@ $(document).ready(function() {
     .done(function(){
       setTimeout(getDialogs, 2000);
     })
-    .fail(function(){
+    .fail(function(e){
+      var errorText = getErrorMessageFromResponse(response)
       $dialogsError.show();
-      $dialogsError.find('.errorMsg').html('Error deleting the dialogs.');
+      $dialogsError.find('.errorMsg').html('Error deleting the dialogs' + (errorText?': '+errorText:'.'));
+      $dialogsError.find('.errorMsg').text('Error  the dialogs.');
       $dName.show();
     })
     .always(function(){
@@ -210,9 +226,10 @@ $(document).ready(function() {
       $('#file').replaceWith($('#file').val('').clone(true));
       getDialogs();
     })
-    .fail(function(){
+    .fail(function(response){
+      var errorText = getErrorMessageFromResponse(response)
       $dialogsError.show();
-      $dialogsError.find('.errorMsg').html('Error creating the dialogs.');
+      $dialogsError.find('.errorMsg').html('Error creating the dialogs' + (errorText?': '+errorText:'.'));
     })
     .always(function(){
       $('#new-dialog-loading').hide();

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -17,7 +17,7 @@ html(lang='en')
 
   body.claro
     div.row.service-container
-      div.col-lg-12.service-header
+      div.service-header
         div.row.top-nav
           div.container
             h3.heading.left IBM 


### PR DESCRIPTION
I Had some trouble creating dialogs using this tool because the error responses from the api were hidden from me. This pull request displays them on the page.
